### PR TITLE
To use the right URL of the repository

### DIFF
--- a/compiler.html
+++ b/compiler.html
@@ -93,7 +93,7 @@
 <div id="content">
 <h1 class="title">μLithp compiler</h1>
 
-<p><i>μLithp</i> - a Lisp in 27 lines of Ruby <a href="http://www.github.com/fogus/ulithp">source</a>
+<p><i>μLithp</i> - a Lisp in 27 lines of Ruby <a href="https://github.com/fogus/ulithp">source</a>
 </p>
 <p>
 <a href="index.html">Primordial ooze</a> | <a href="reader.html">A reader</a> | <a href="repl.html">REPL</a> | <a href="compiler.html">A compiler</a> | <a href="interop.html">Ruby interop</a>

--- a/header/header.org
+++ b/header/header.org
@@ -1,4 +1,4 @@
-/μLithp/ - a Lisp in 27 lines of Ruby [[http://www.github.com/fogus/ulithp][source]]
+/μLithp/ - a Lisp in 27 lines of Ruby [[https://github.com/fogus/ulithp][source]]
 
 [[file:index.org][Primordial ooze]] | [[file:reader.org][A reader]] | [[file:repl.org][REPL]] | [[file:compiler.org][A compiler]] | [[file:interop.org][Ruby interop]]
 

--- a/index.html
+++ b/index.html
@@ -93,7 +93,7 @@
 <div id="content">
 <h1 class="title">μLithp</h1>
 
-<p><i>μLithp</i> - a Lisp in 27 lines of Ruby <a href="http://www.github.com/fogus/ulithp">source</a>
+<p><i>μLithp</i> - a Lisp in 27 lines of Ruby <a href="https://github.com/fogus/ulithp">source</a>
 </p>
 <p>
 <a href="index.html">Primordial ooze</a> | <a href="reader.html">A reader</a> | <a href="repl.html">REPL</a> | <a href="compiler.html">A compiler</a> | <a href="interop.html">Ruby interop</a>

--- a/interop.html
+++ b/interop.html
@@ -93,7 +93,7 @@
 <div id="content">
 <h1 class="title">μLithp interop</h1>
 
-<p><i>μLithp</i> - a Lisp in 27 lines of Ruby <a href="http://www.github.com/fogus/ulithp">source</a>
+<p><i>μLithp</i> - a Lisp in 27 lines of Ruby <a href="https://github.com/fogus/ulithp">source</a>
 </p>
 <p>
 <a href="index.html">Primordial ooze</a> | <a href="reader.html">A reader</a> | <a href="repl.html">REPL</a> | <a href="compiler.html">A compiler</a> | <a href="interop.html">Ruby interop</a>

--- a/reader.html
+++ b/reader.html
@@ -93,7 +93,7 @@
 <div id="content">
 <h1 class="title">μLithp reader</h1>
 
-<p><i>μLithp</i> - a Lisp in 27 lines of Ruby <a href="http://www.github.com/fogus/ulithp">source</a>
+<p><i>μLithp</i> - a Lisp in 27 lines of Ruby <a href="https://github.com/fogus/ulithp">source</a>
 </p>
 <p>
 <a href="index.html">Primordial ooze</a> | <a href="reader.html">A reader</a> | <a href="repl.html">REPL</a> | <a href="compiler.html">A compiler</a> | <a href="interop.html">Ruby interop</a>

--- a/repl.html
+++ b/repl.html
@@ -93,7 +93,7 @@
 <div id="content">
 <h1 class="title">μLithp REPL</h1>
 
-<p><i>μLithp</i> - a Lisp in 27 lines of Ruby <a href="http://www.github.com/fogus/ulithp">source</a>
+<p><i>μLithp</i> - a Lisp in 27 lines of Ruby <a href="https://github.com/fogus/ulithp">source</a>
 </p>
 <p>
 <a href="index.html">Primordial ooze</a> | <a href="reader.html">A reader</a> | <a href="repl.html">REPL</a> | <a href="compiler.html">A compiler</a> | <a href="interop.html">Ruby interop</a>


### PR DESCRIPTION
It seems that `http://www.github.com/fogus/ulithp` is been redirected to `http://www.github.com/static/index.html`.

Either `http://github.com/fogus/ulithp` or `https://github.com/fogus/ulithp` will link to the right page. I'd prefer the latter :)
